### PR TITLE
Use pre-commit as the linter

### DIFF
--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: ['3.7', '3.8', '3.9']
+        python: ["3.7", "3.8", "3.9", "3.10"]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
-          architecture: 'x64'
+          architecture: "x64"
       - name: Install system dependencies
         run: sudo apt install -y libkrb5-dev
       - name: Cache venv
@@ -47,39 +47,3 @@ jobs:
           file: ./coverage.xml
           flags: unittests
           name: codecov-umbrella
-  lint:
-    name: flake8 & black
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
-        with:
-          python-version: 3.7
-          architecture: 'x64'
-      - name: Cache venv
-        uses: actions/cache@v2
-        with:
-          path: venv
-          # Look to see if there is a cache hit for the corresponding requirements file
-          key: lintenv-v2
-      - name: Install Dependencies
-        run: |
-          python3 -m venv venv
-          . venv/bin/activate
-          pip install -U pip flake8 black
-      - name: Flake8 test
-        run: |
-          . venv/bin/activate
-          flake8 .
-      - name: Black test
-        run: |
-          . venv/bin/activate
-          black --check .
-  spellcheck:
-    name: spellcheck
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: codespell-project/actions-codespell@master

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,34 @@
+ci:
+  autoupdate_schedule: monthly
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
+    hooks:
+      - id: check-toml
+      - id: check-yaml
+      - id: end-of-file-fixer
+        exclude: dev_datadir/
+      - id: trailing-whitespace
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.1.0
+    hooks:
+      - id: codespell
+
+  - repo: https://github.com/psf/black
+    rev: 21.12b0
+    hooks:
+      - id: black
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          - flake8-bugbear

--- a/lobbyboy/config.py
+++ b/lobbyboy/config.py
@@ -1,17 +1,19 @@
+import importlib
 import json
 import logging
 import time
-import importlib
 from collections import OrderedDict
-from dataclasses import dataclass, replace, field, fields, asdict
+from dataclasses import asdict, dataclass, field, fields, replace
 from json import JSONDecodeError
 from pathlib import Path
-from typing import Dict, List, Tuple, OrderedDict as typeOrderedDict, Optional
+from typing import Dict, List, Optional
+from typing import OrderedDict as typeOrderedDict
+from typing import Tuple
 
 import toml
 
 from lobbyboy.exceptions import InvalidConfigException
-from lobbyboy.utils import lb_dict_factory, confirm_dc_type
+from lobbyboy.utils import confirm_dc_type, lb_dict_factory
 
 logger = logging.getLogger(__name__)
 

--- a/lobbyboy/contrib/provider/digitalocean.py
+++ b/lobbyboy/contrib/provider/digitalocean.py
@@ -1,15 +1,15 @@
-import os
 import logging
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List, Tuple
 
-from digitalocean import Droplet, Region, Size, Image, Manager
+from digitalocean import Droplet, Image, Manager, Region, Size
 from paramiko.channel import Channel
 
-from lobbyboy.provider import BaseProvider
-from lobbyboy.utils import send_to_channel, port_is_open, choose_option, lb_dict_factory
 from lobbyboy.config import LBConfigProvider, LBServerMeta
+from lobbyboy.provider import BaseProvider
+from lobbyboy.utils import choose_option, lb_dict_factory, port_is_open, send_to_channel
 
 logger = logging.getLogger(__name__)
 ENV_TOKEN_NAME = "DIGITALOCEAN_TOKEN"

--- a/lobbyboy/contrib/provider/footloose.py
+++ b/lobbyboy/contrib/provider/footloose.py
@@ -1,17 +1,16 @@
 import logging
-from pathlib import Path
-from dataclasses import dataclass
 import subprocess
 import sys
+from dataclasses import dataclass
+from pathlib import Path
 from typing import List
 
 from paramiko import Channel
 
-from lobbyboy.config import LBServerMeta, LBConfigProvider
+from lobbyboy.config import LBConfigProvider, LBServerMeta
 from lobbyboy.exceptions import ProviderException
 from lobbyboy.provider import BaseProvider
 from lobbyboy.utils import send_to_channel
-
 
 logger = logging.getLogger(__name__)
 

--- a/lobbyboy/contrib/provider/ignite.py
+++ b/lobbyboy/contrib/provider/ignite.py
@@ -1,17 +1,16 @@
 import logging
-from pathlib import Path
 import subprocess
 import sys
-from typing import List
 from dataclasses import dataclass
+from pathlib import Path
+from typing import List
 
 from paramiko import Channel
 
-from lobbyboy.config import LBServerMeta, LBConfigProvider
+from lobbyboy.config import LBConfigProvider, LBServerMeta
 from lobbyboy.exceptions import ProviderException
 from lobbyboy.provider import BaseProvider
 from lobbyboy.utils import send_to_channel
-
 
 logger = logging.getLogger(__name__)
 

--- a/lobbyboy/contrib/provider/linode.py
+++ b/lobbyboy/contrib/provider/linode.py
@@ -1,15 +1,15 @@
-import os
 import logging
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List, Tuple
 
-from linode_api4 import LinodeClient, Region, Type, Image, Instance
+from linode_api4 import Image, Instance, LinodeClient, Region, Type
 from paramiko.channel import Channel
 
-from lobbyboy.provider import BaseProvider
-from lobbyboy.utils import send_to_channel, port_is_open, choose_option
 from lobbyboy.config import LBConfigProvider, LBServerMeta
+from lobbyboy.provider import BaseProvider
+from lobbyboy.utils import choose_option, port_is_open, send_to_channel
 
 logger = logging.getLogger(__name__)
 ENV_TOKEN_NAME = "LINODE_TOKEN"

--- a/lobbyboy/contrib/provider/multipass.py
+++ b/lobbyboy/contrib/provider/multipass.py
@@ -1,18 +1,17 @@
-import logging
 import json
-from pathlib import Path
+import logging
 import subprocess
 import sys
-from typing import List
 from dataclasses import dataclass
+from pathlib import Path
+from typing import List
 
 from paramiko import Channel
 
-from lobbyboy.config import LBServerMeta, LBConfigProvider
+from lobbyboy.config import LBConfigProvider, LBServerMeta
 from lobbyboy.exceptions import ProviderException
 from lobbyboy.provider import BaseProvider
 from lobbyboy.utils import send_to_channel
-
 
 logger = logging.getLogger(__name__)
 

--- a/lobbyboy/contrib/provider/vagrant.py
+++ b/lobbyboy/contrib/provider/vagrant.py
@@ -1,13 +1,13 @@
-from dataclasses import dataclass
 import logging
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional
 
 from paramiko import Channel
 
 from lobbyboy.config import LBConfigProvider, LBServerMeta
-from lobbyboy.exceptions import VagrantProviderException, NoAvailableNameException
+from lobbyboy.exceptions import NoAvailableNameException, VagrantProviderException
 from lobbyboy.provider import BaseProvider
 from lobbyboy.utils import send_to_channel
 

--- a/lobbyboy/main.py
+++ b/lobbyboy/main.py
@@ -10,10 +10,10 @@ import traceback
 from pathlib import Path
 from typing import Dict
 
-from lobbyboy.config import LBConfig, load_config, LBConfigProvider
+from lobbyboy.config import LBConfig, LBConfigProvider, load_config
 from lobbyboy.provider import BaseProvider
-from lobbyboy.socket_handle import SocketHandlerThread
 from lobbyboy.server_killer import ServerKiller
+from lobbyboy.socket_handle import SocketHandlerThread
 from lobbyboy.utils import confirm_ssh_key_pair, to_seconds
 
 # TODO generate all keys when start, if key not exist.

--- a/lobbyboy/provider.py
+++ b/lobbyboy/provider.py
@@ -1,22 +1,18 @@
 import json
+import logging
 import string
+import subprocess
+import time
 from abc import ABC, abstractmethod
 from datetime import datetime
 from pathlib import Path
-import logging
-import subprocess
-import time
-from typing import List, Dict, Callable
+from typing import Callable, Dict, List
 
 from paramiko.channel import Channel
 
-from lobbyboy.exceptions import NoAvailableNameException
-from lobbyboy.utils import (
-    confirm_ssh_key_pair,
-    send_to_channel,
-    KeyTypeSupport,
-)
 from lobbyboy.config import LBConfigProvider, LBServerMeta
+from lobbyboy.exceptions import NoAvailableNameException
+from lobbyboy.utils import KeyTypeSupport, confirm_ssh_key_pair, send_to_channel
 
 logger = logging.getLogger(__name__)
 SERVER_FILE = "server.json"

--- a/lobbyboy/server.py
+++ b/lobbyboy/server.py
@@ -12,7 +12,7 @@ from binascii import hexlify
 import paramiko
 
 from lobbyboy.config import LBConfig
-from lobbyboy.exceptions import UnsupportedPrivateKeyTypeException, NoTTYException
+from lobbyboy.exceptions import NoTTYException, UnsupportedPrivateKeyTypeException
 
 logger = logging.getLogger(__name__)
 

--- a/lobbyboy/server_killer.py
+++ b/lobbyboy/server_killer.py
@@ -5,9 +5,14 @@ from typing import Dict, OrderedDict, Tuple
 
 from paramiko import Channel
 
+from lobbyboy.config import LBConfig, LBConfigProvider, LBServerMeta
 from lobbyboy.provider import BaseProvider
-from lobbyboy.utils import available_server_db_lock, humanize_seconds, active_session, to_seconds
-from lobbyboy.config import LBConfigProvider, LBServerMeta, LBConfig
+from lobbyboy.utils import (
+    active_session,
+    available_server_db_lock,
+    humanize_seconds,
+    to_seconds,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/lobbyboy/socket_handle.py
+++ b/lobbyboy/socket_handle.py
@@ -1,36 +1,37 @@
-from typing import OrderedDict, Tuple, Optional
-
+import logging
 import os
+import select
 import socket
 import threading
-import select
-import logging
-from io import StringIO
 from binascii import hexlify
-from typing import Dict
-
+from io import StringIO
 from subprocess import Popen
+from typing import Dict, Optional, OrderedDict, Tuple
 
 import paramiko
 from paramiko.channel import Channel
 from paramiko.transport import Transport
 
+from lobbyboy import __version__
+from lobbyboy.config import LBConfig, LBServerMeta
+from lobbyboy.exceptions import (
+    NoProviderException,
+    ProviderException,
+    UserCancelException,
+)
+from lobbyboy.provider import BaseProvider
 from lobbyboy.server import Server
 from lobbyboy.server_killer import ServerKiller
 from lobbyboy.utils import (
-    available_server_db_lock,
-    active_session_lock,
     DoGSSAPIKeyExchange,
-    send_to_channel,
-    active_session,
     KeyTypeSupport,
+    active_session,
+    active_session_lock,
+    available_server_db_lock,
     choose_option,
     confirm_ssh_key_pair,
+    send_to_channel,
 )
-from lobbyboy.config import LBConfig, LBServerMeta
-from lobbyboy.exceptions import UserCancelException, ProviderException, NoProviderException
-from lobbyboy.provider import BaseProvider
-from lobbyboy import __version__
 
 logger = logging.getLogger(__name__)
 

--- a/lobbyboy/utils.py
+++ b/lobbyboy/utils.py
@@ -1,18 +1,22 @@
+import logging
 import os
 import re
-import logging
 import socket
 import threading
-from datetime import timedelta, datetime, date
+from datetime import date, datetime, timedelta
 from enum import Enum, unique
 from io import StringIO
 from pathlib import Path
-from typing import List, Dict, Tuple, Callable, Union, Any, Type, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 import paramiko
 from paramiko.channel import Channel
 
-from lobbyboy.exceptions import UnsupportedPrivateKeyTypeException, UserCancelException, TimeStrParseTypeException
+from lobbyboy.exceptions import (
+    TimeStrParseTypeException,
+    UnsupportedPrivateKeyTypeException,
+    UserCancelException,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -21,6 +21,21 @@ tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)"
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
 
 [[package]]
+name = "backports.entry-points-selectable"
+version = "1.1.1"
+description = "Compatibility shim providing selectable entry points for older implementations"
+category = "dev"
+optional = false
+python-versions = ">=2.7"
+
+[package.dependencies]
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest", "pytest-flake8", "pytest-cov", "pytest-black (>=0.3.7)", "pytest-mypy", "pytest-checkdocs (>=2.4)", "pytest-enabler (>=1.0.1)"]
+
+[[package]]
 name = "bcrypt"
 version = "3.2.0"
 description = "Modern password hashing for your software and your servers"
@@ -103,6 +118,14 @@ python-versions = "*"
 pycparser = "*"
 
 [[package]]
+name = "cfgv"
+version = "3.3.1"
+description = "Validate configuration and produce human readable error messages."
+category = "dev"
+optional = false
+python-versions = ">=3.6.1"
+
+[[package]]
 name = "charset-normalizer"
 version = "2.0.7"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
@@ -175,6 +198,26 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
+name = "distlib"
+version = "0.3.4"
+description = "Distribution utilities"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "filelock"
+version = "3.4.0"
+description = "A platform independent file lock."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+docs = ["furo (>=2021.8.17b43)", "sphinx (>=4.1)", "sphinx-autodoc-typehints (>=1.12)"]
+testing = ["covdefaults (>=1.2.0)", "coverage (>=4)", "pytest (>=4)", "pytest-cov", "pytest-timeout (>=1.4.2)"]
+
+[[package]]
 name = "flake8"
 version = "4.0.1"
 description = "the modular source code checker: pep8 pyflakes and co"
@@ -209,6 +252,17 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 decorator = "*"
+
+[[package]]
+name = "identify"
+version = "2.4.0"
+description = "File identification library for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.6.1"
+
+[package.extras]
+license = ["ukkonen"]
 
 [[package]]
 name = "idna"
@@ -286,6 +340,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "nodeenv"
+version = "1.6.0"
+description = "Node.js virtual environment builder"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "packaging"
 version = "21.0"
 description = "Core utilities for Python packages"
@@ -352,6 +414,23 @@ importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "pre-commit"
+version = "2.16.0"
+description = "A framework for managing and maintaining multi-language pre-commit hooks."
+category = "dev"
+optional = false
+python-versions = ">=3.6.1"
+
+[package.dependencies]
+cfgv = ">=2.0.0"
+identify = ">=1.0.0"
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+nodeenv = ">=0.11.1"
+pyyaml = ">=5.1"
+toml = "*"
+virtualenv = ">=20.0.8"
 
 [[package]]
 name = "py"
@@ -489,6 +568,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "pyyaml"
+version = "6.0"
+description = "YAML parser and emitter for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "regex"
 version = "2021.10.23"
 description = "Alternative regular expression module, to replace re."
@@ -568,6 +655,26 @@ secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "cer
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
+name = "virtualenv"
+version = "20.10.0"
+description = "Virtual Python Environment builder"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[package.dependencies]
+"backports.entry-points-selectable" = ">=1.0.4"
+distlib = ">=0.3.1,<1"
+filelock = ">=3.2,<4"
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+platformdirs = ">=2,<3"
+six = ">=1.9.0,<2"
+
+[package.extras]
+docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=21.3)"]
+testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "packaging (>=20.0)"]
+
+[[package]]
 name = "zipp"
 version = "3.6.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
@@ -582,7 +689,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "08e6746dbabc853de4a5e00858d1428df38b6007f84693d2ce3dbfafcbc7079c"
+content-hash = "0dca433830070f7c7cc7b3fe832616a7e0aad17ffc1215bde7334fb936dc3694"
 
 [metadata.files]
 atomicwrites = [
@@ -592,6 +699,10 @@ atomicwrites = [
 attrs = [
     {file = "attrs-21.2.0-py2.py3-none-any.whl", hash = "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1"},
     {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
+]
+"backports.entry-points-selectable" = [
+    {file = "backports.entry_points_selectable-1.1.1-py2.py3-none-any.whl", hash = "sha256:7fceed9532a7aa2bd888654a7314f864a3c16a4e710b34a58cfc0f08114c663b"},
+    {file = "backports.entry_points_selectable-1.1.1.tar.gz", hash = "sha256:914b21a479fde881635f7af5adc7f6e38d6b274be32269070c53b698c60d5386"},
 ]
 bcrypt = [
     {file = "bcrypt-3.2.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:c95d4cbebffafcdd28bd28bb4e25b31c50f6da605c81ffd9ad8a3d1b2ab7b1b6"},
@@ -669,6 +780,10 @@ cffi = [
     {file = "cffi-1.15.0-cp39-cp39-win32.whl", hash = "sha256:2a23af14f408d53d5e6cd4e3d9a24ff9e05906ad574822a10563efcef137979a"},
     {file = "cffi-1.15.0-cp39-cp39-win_amd64.whl", hash = "sha256:3773c4d81e6e818df2efbc7dd77325ca0dcb688116050fb2b3011218eda36139"},
     {file = "cffi-1.15.0.tar.gz", hash = "sha256:920f0d66a896c2d99f0adbb391f990a84091179542c205fa53ce5787aff87954"},
+]
+cfgv = [
+    {file = "cfgv-3.3.1-py2.py3-none-any.whl", hash = "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426"},
+    {file = "cfgv-3.3.1.tar.gz", hash = "sha256:f5a830efb9ce7a445376bb66ec94c638a9787422f96264c98edc6bdeed8ab736"},
 ]
 charset-normalizer = [
     {file = "charset-normalizer-2.0.7.tar.gz", hash = "sha256:e019de665e2bcf9c2b64e2e5aa025fa991da8720daa3c1138cadd2fd1856aed0"},
@@ -757,6 +872,14 @@ decorator = [
     {file = "decorator-5.1.0-py3-none-any.whl", hash = "sha256:7b12e7c3c6ab203a29e157335e9122cb03de9ab7264b137594103fd4a683b374"},
     {file = "decorator-5.1.0.tar.gz", hash = "sha256:e59913af105b9860aa2c8d3272d9de5a56a4e608db9a2f167a8480b323d529a7"},
 ]
+distlib = [
+    {file = "distlib-0.3.4-py2.py3-none-any.whl", hash = "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b"},
+    {file = "distlib-0.3.4.zip", hash = "sha256:e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579"},
+]
+filelock = [
+    {file = "filelock-3.4.0-py3-none-any.whl", hash = "sha256:2e139a228bcf56dd8b2274a65174d005c4a6b68540ee0bdbb92c76f43f29f7e8"},
+    {file = "filelock-3.4.0.tar.gz", hash = "sha256:93d512b32a23baf4cac44ffd72ccf70732aeff7b8050fcaf6d3ec406d954baf4"},
+]
 flake8 = [
     {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
     {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
@@ -786,6 +909,10 @@ gssapi = [
     {file = "gssapi-1.7.2-cp39-cp39-win_amd64.whl", hash = "sha256:a01dbcd17760cdd77701006105e00a1bd213bd6e189b6602242f175ab488afee"},
     {file = "gssapi-1.7.2.tar.gz", hash = "sha256:748efbcf7cfb31183cd75e5314493e79fe3521b3ec00d090a77e23f7c75fa59d"},
 ]
+identify = [
+    {file = "identify-2.4.0-py2.py3-none-any.whl", hash = "sha256:eba31ca80258de6bb51453084bff4a923187cd2193b9c13710f2516ab30732cc"},
+    {file = "identify-2.4.0.tar.gz", hash = "sha256:a33ae873287e81651c7800ca309dc1f84679b763c9c8b30680e16fbfa82f0107"},
+]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
@@ -814,6 +941,10 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
+nodeenv = [
+    {file = "nodeenv-1.6.0-py2.py3-none-any.whl", hash = "sha256:621e6b7076565ddcacd2db0294c0381e01fd28945ab36bcf00f41c5daf63bef7"},
+    {file = "nodeenv-1.6.0.tar.gz", hash = "sha256:3ef13ff90291ba2a4a7a4ff9a979b63ffdd00a464dbe04acf0ea6471517a4c2b"},
+]
 packaging = [
     {file = "packaging-21.0-py3-none-any.whl", hash = "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"},
     {file = "packaging-21.0.tar.gz", hash = "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7"},
@@ -833,6 +964,10 @@ platformdirs = [
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
+pre-commit = [
+    {file = "pre_commit-2.16.0-py2.py3-none-any.whl", hash = "sha256:758d1dc9b62c2ed8881585c254976d66eae0889919ab9b859064fc2fe3c7743e"},
+    {file = "pre_commit-2.16.0.tar.gz", hash = "sha256:fe9897cac830aa7164dbd02a4e7b90cae49630451ce88464bca73db486ba9f65"},
 ]
 py = [
     {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
@@ -916,6 +1051,41 @@ pywin32 = [
     {file = "pywin32-302-cp38-cp38-win_amd64.whl", hash = "sha256:543552e66936378bd2d673c5a0a3d9903dba0b0a87235ef0c584f058ceef5872"},
     {file = "pywin32-302-cp39-cp39-win32.whl", hash = "sha256:2393c1a40dc4497fd6161b76801b8acd727c5610167762b7c3e9fd058ef4a6ab"},
     {file = "pywin32-302-cp39-cp39-win_amd64.whl", hash = "sha256:af5aea18167a31efcacc9f98a2ca932c6b6a6d91ebe31f007509e293dea12580"},
+]
+pyyaml = [
+    {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
+    {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
+    {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
+    {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
+    {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4"},
+    {file = "PyYAML-6.0-cp36-cp36m-win32.whl", hash = "sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293"},
+    {file = "PyYAML-6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57"},
+    {file = "PyYAML-6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9"},
+    {file = "PyYAML-6.0-cp37-cp37m-win32.whl", hash = "sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737"},
+    {file = "PyYAML-6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d"},
+    {file = "PyYAML-6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287"},
+    {file = "PyYAML-6.0-cp38-cp38-win32.whl", hash = "sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78"},
+    {file = "PyYAML-6.0-cp38-cp38-win_amd64.whl", hash = "sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0"},
+    {file = "PyYAML-6.0-cp39-cp39-win32.whl", hash = "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb"},
+    {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
+    {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
 regex = [
     {file = "regex-2021.10.23-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:45b65d6a275a478ac2cbd7fdbf7cc93c1982d613de4574b56fd6972ceadb8395"},
@@ -1011,6 +1181,10 @@ typing-extensions = [
 urllib3 = [
     {file = "urllib3-1.26.7-py2.py3-none-any.whl", hash = "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"},
     {file = "urllib3-1.26.7.tar.gz", hash = "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece"},
+]
+virtualenv = [
+    {file = "virtualenv-20.10.0-py2.py3-none-any.whl", hash = "sha256:4b02e52a624336eece99c96e3ab7111f469c24ba226a53ec474e8e787b365814"},
+    {file = "virtualenv-20.10.0.tar.gz", hash = "sha256:576d05b46eace16a9c348085f7d0dc8ef28713a2cabaa1cf0aea41e8f12c9218"},
 ]
 zipp = [
     {file = "zipp-3.6.0-py3-none-any.whl", hash = "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ pytest = "^6.2.5"
 flake8 = "^4.0.1"
 freezegun = "^1.1.0"
 pytest-cov = "^3.0.0"
+pre-commit = "^2.16.0"
 
 [tool.black]
 target-version = ["py37"]
@@ -34,3 +35,7 @@ line-length = 120
 
 [tool.coverage.run]
 source = ["lobbyboy"]
+
+[tool.isort]
+profile = "black"
+atomic = true

--- a/tests/test_providers/conftest.py
+++ b/tests/test_providers/conftest.py
@@ -1,8 +1,10 @@
-from lobbyboy.config import LBServerMeta
 import shutil
-from lobbyboy.contrib.provider.footloose import FootlooseProvider, FootlooseConfig
-import pytest
 from pathlib import Path
+
+import pytest
+
+from lobbyboy.config import LBServerMeta
+from lobbyboy.contrib.provider.footloose import FootlooseConfig, FootlooseProvider
 
 
 @pytest.fixture

--- a/tests/test_providers/test_footloose.py
+++ b/tests/test_providers/test_footloose.py
@@ -1,9 +1,11 @@
-from lobbyboy.config import LBServerMeta
 import re
-from unittest import mock
-from freezegun import freeze_time
 from pathlib import Path
+from unittest import mock
 from unittest.mock import call
+
+from freezegun import freeze_time
+
+from lobbyboy.config import LBServerMeta
 
 
 @mock.patch("subprocess.run")


### PR DESCRIPTION
Close #48 

Install the commit hooks in dev:

```bash
poetry run pre-commit install
```

Run in CI: I recommend using [pre-commit ci](https://pre-commit.ci/), it can upgrade the hooks and commit linter changes automatically. It is also blazing fast, e2e run time is < 10s

BTW, the code is changed by the linter so this is better to merge after #55, otherwise there will be lots of conflicts